### PR TITLE
Kbit distance with Single Matching distance

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -29,7 +29,7 @@ export default {
             compress: {ecma: 2015, passes: 3, unsafe: true},
             mangle: {
               properties: {
-                reserved: ['biomsa']
+                reserved: ['biomsa', 'gapopen', 'gapextend', 'matrix', 'method', 'type', 'gapchar', 'debug']
               }
             },
             nameCache: {}


### PR DESCRIPTION
## Fixes
- fix options names mangled through the minimization process
- use Single Matching Distance to better compensate for unrelated sequences Kmer sharing.