### PR TITLE
Weight-scheme-fixes

### DIFF
--- a/src/align/align.ts
+++ b/src/align/align.ts
@@ -250,7 +250,7 @@ export function MSASeqAlignment(
 ) {
 
     const seqB = nodeB.seq,
-        //wA = noeudA.weight, //probably unnecessary
+        wB = nodeB.weight,
         lSeqBLen = seqB.rawSeq.length,
         lProfALen = nodeA.profile.length;
 
@@ -278,7 +278,7 @@ export function MSASeqAlignment(
         /** Position specific substitution scores of profile A at pos i-1 */
         lProfASScores = new Float32Array(params.abSize);
 
-    const GAP_OPEN    = params.gapOP;
+    const GAP_OPEN    = params.gapOP * wB;
     const GAP_OPEN_B  = GAP_OPEN / 2;
     const GAP_CLOSE_B = GAP_OPEN / 2;
 

--- a/src/align/align.ts
+++ b/src/align/align.ts
@@ -520,7 +520,7 @@ export function MSAMSAAlignment(
             lResList = profB.m_uSortOrder.subarray(lOffset, lOffset + kmax );
             while (k < kmax) {
                 lResProfNb = lResList[k];
-                lMatch += profB.m_wCounts[lOffset + lResProfNb] * lProfAAAScores[lResProfNb];
+                lMatch += lProfAAAScores[lResProfNb];   // weighted scores already used here. Do not multiply by weight.
                 k++;
             }
 

--- a/src/sequence/profile.ts
+++ b/src/sequence/profile.ts
@@ -414,10 +414,10 @@ export function mergeProfiles (pProfA: ProfPos, pProfB: ProfPos, pESA: number[],
             lProx.m_fcCounts.set(lProxA.m_fcCounts);
             lProx.m_wCounts .set(lProxA.m_wCounts);
             for (let i = 0; i < pProfB.alphaSize; i++) {
-                let v = pProfB.m_fcCounts[i];
+                let v = lProxB.m_fcCounts[i];
                 if (v) {
                     lProx.m_fcCounts[i] += v;
-                    lProx.m_wCounts[i] += pProfB.m_wCounts[i];
+                    lProx.m_wCounts[i] += lProxB.m_wCounts[i];
                 }
                 if (lProx.m_fcCounts[i]) {
                     lProx.m_uSortOrder[lNbRes] = i;

--- a/src/sequence/sequence.ts
+++ b/src/sequence/sequence.ts
@@ -300,8 +300,8 @@ export function distanceMatrix(tabSeq: TSequence[]) {
             commonKbitsCount -= expectedRandomMatches;
             commonKbitsCount = Math.max(commonKbitsCount, 0)
 
-            // Tanimoto/Jacquard distance corrected for random matches
-            distance = 1 - (commonKbitsCount / bitsetLength);
+            // Simple Matching distance corrected for random matches
+            distance = 1 - (commonKbitsCount / (bitsetLength - expectedRandomMatches));
             distTab[j][i] = distTab[i][j] = distance;
         }
 

--- a/src/sequence/tree.ts
+++ b/src/sequence/tree.ts
@@ -5,7 +5,7 @@
  * @copyright 2020
  */
 
-import { TAlignmentParam } from '../align/params';
+import { DEBUG, TAlignmentParam } from '../align/params';
 import { seqToProf, ProfPos } from './profile';
 import { TSequence } from './sequence';
 
@@ -106,6 +106,10 @@ export function makeTree(mD: number[][], tSeq: TSequence[]) {
     }
 
     clusters[clusters.length - 1].type = NODE_TYPE.ROOT;
+
+    if (DEBUG) {
+        console.table(clusters)
+    }
 
     return clusters;
 }
@@ -282,7 +286,13 @@ function recomputeDistMatrix(matrix: number[][], x: number, y: number, tI: numbe
 
     setWeight(root);
 
-    return cluster.map(c => c.weight);
+    const weights = cluster.map(c => c.weight);
+
+    if (DEBUG) {
+        console.table(weights)
+    }
+
+    return weights
 };
 
 /**


### PR DESCRIPTION
## Fixes
- Weight applied twice (squared) in matches score calculation in profile vs profile alignment
- Weight not applied on gaps in sequence vs profile alignment
- Error in residue frequence computation when merging profiles

## Improvements
-  Simple Matching Distance computation tweaked, so that identical sequences have a distance of 0.